### PR TITLE
When getting the max number of inserts only look for single '%'s.

### DIFF
--- a/lib/win32/eventlog.rb
+++ b/lib/win32/eventlog.rb
@@ -1080,7 +1080,7 @@ module Win32
           }
 
           # Determine higest %n insert number
-          max_insert = [num, buf.read_string.scan(/%(\d+)/).map{ |x| x[0].to_i }.max].compact.max
+          max_insert = [num, buf.read_string.scan(/(?<!%%)(?<=%)(\d+)/).map{ |x| x[0].to_i }.max].compact.max
 
           # Insert dummy strings not provided by caller
           ((num+1)..(max_insert)).each{ |x| va_list.push("%#{x}") }

--- a/lib/win32/eventlog.rb
+++ b/lib/win32/eventlog.rb
@@ -59,6 +59,10 @@ module Win32
     # Failure audit event, an event that records an audited security attempt
     # that fails.
     AUDIT_FAILURE = EVENTLOG_AUDIT_FAILURE
+    
+    # Regex to find inserts in format messages.
+    # See https://msdn.microsoft.com/en-us/library/windows/desktop/ms679351(v=vs.85).aspx
+    INSERT_NUMBER_REGEX = /(?<!%%)(?<=%)(\d+)/
 
     # The EventLogStruct encapsulates a single event log record.
     EventLogStruct = Struct.new('EventLogStruct', :record_number,
@@ -1080,7 +1084,7 @@ module Win32
           }
 
           # Determine higest %n insert number
-          max_insert = [num, buf.read_string.scan(/(?<!%%)(?<=%)(\d+)/).map{ |x| x[0].to_i }.max].compact.max
+          max_insert = [num, buf.read_string.scan(INSERT_NUMBER_REGEX).map{ |x| x[0].to_i }.max].compact.max
 
           # Insert dummy strings not provided by caller
           ((num+1)..(max_insert)).each{ |x| va_list.push("%#{x}") }

--- a/test/test_eventlog.rb
+++ b/test/test_eventlog.rb
@@ -311,6 +311,14 @@ class TC_Win32_EventLog < Test::Unit::TestCase
     assert_not_nil(EventLog::AUDIT_FAILURE)
   end
 
+  test "insert number regex" do
+    assert_equal([["1"]], "%1".scan(EventLog::INSERT_NUMBER_REGEX))
+    assert_equal([], "%%1".scan(EventLog::INSERT_NUMBER_REGEX))
+    assert_equal([["1234"]], "apple%1234red".scan(EventLog::INSERT_NUMBER_REGEX))
+    assert_equal([], "apple%%1234red".scan(EventLog::INSERT_NUMBER_REGEX))
+    assert_equal([["1"], ["2"], ["2"], ["5"]], "This %1 is %2 a %%4321 test%2message%%3! %5".scan(EventLog::INSERT_NUMBER_REGEX))
+  end
+
   def teardown
     @log.close rescue nil
     File.delete(@bakfile) if File.exist?(@bakfile)


### PR DESCRIPTION
This can cause an issue as the formatting for windows event logs uses '%%' for a '%'.  So if we get a message like "%1 process was at %%100000000" an array of 100 million will be created.

See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms679351(v=vs.85).aspx